### PR TITLE
fix: make join us section responsive

### DIFF
--- a/src/components/JoinUs/JoinUs.jsx
+++ b/src/components/JoinUs/JoinUs.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import "./joinus.css";
 
 const JoinUs = () => {

--- a/src/components/JoinUs/joinus.css
+++ b/src/components/JoinUs/joinus.css
@@ -5,10 +5,11 @@
 
 .joinus-container {
   display: flex;
+  gap: 1rem;
   position: relative;
   justify-content: space-between;
   align-items: center;
-  background: linear-gradient(163deg,#000000,#0b1059);
+  background: linear-gradient(163deg, #000000, #0b1059);
   color: #ffffff;
   padding: 2vh 8vh;
   border-radius: 4vh;
@@ -45,4 +46,15 @@
   padding: 1.8vh 6.5vh;
   border-radius: 2vh;
   border: none;
+  width: max-content;
+}
+
+@media screen and (max-width: 768px) {
+  .joinus-container {
+    flex-direction: column;
+    height: auto;
+  }
+  .invite-content :is(h1, p) {
+    text-align: center;
+  }
 }


### PR DESCRIPTION
closes #105

![Join us section image](https://github.com/WikiPortal/DoodleCollab/assets/117534561/967be0c1-e14e-46ea-8573-5dc6179b7ed1)


Made the join us section responsive for all the devices.

issue no. #105