### PR TITLE
fix: Rename <p> text and add text of banner section

### DIFF
--- a/src/components/Banner/HomeBanner.jsx
+++ b/src/components/Banner/HomeBanner.jsx
@@ -118,7 +118,8 @@ const HomeBanner = () => {
                   </div>
                 </div>
                 <div className="homebanner-card-first-column-third-row">
-                  <p>lorem Ipsum</p>
+                  <p>John Doe</p>
+                  <p>Engineer</p>
                 </div>
                 <div className="homebanner-card-first-column-fourth-row">
                   <button className="follow">


### PR DESCRIPTION
### Issue: #145

### Description:

_Rename the "lorem Ipsum" name of banner section to "John Doe" and under that add "Engineer" as text_

## Before:
![imagen](https://github.com/WikiPortal/DoodleCollab/assets/124620126/1b90047a-9e61-4e2a-8cbc-5817b1a81fc1)

## After:
![imagen](https://github.com/WikiPortal/DoodleCollab/assets/124620126/fe2ae76d-2804-4aa7-a23b-6013c52e1125)

## Checklist ✅

- [X] I checked and didn't find similar [issue](https://github.com/WikiPortal/DoodleCollab/issues)
- [X] I have read the [Contributing Guidelines](https://github.com/WikiPortal/DoodleCollab/blob/main/CONTRIBUTING.md)
- [X] I am participating in JWOC
- [ ] I am participating in IWOC
- [X] I am willing to work on this issue (blank for no)